### PR TITLE
REST API template versionning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ script:
   - sleep 5
   - "npm run test-node"
   - "npm run test"
+  - "npm run lint"

--- a/README.md
+++ b/README.md
@@ -34,4 +34,7 @@ npm run start
 npm run lint
 npm run test
 npm run test-node
+
+//run REST API sigle test
+make test FILE=[complete_path_to_file]
 ```

--- a/src/api/modules/templates/__tests__/template-versions-test.js
+++ b/src/api/modules/templates/__tests__/template-versions-test.js
@@ -1,0 +1,196 @@
+import {expect} from 'chai';
+import co from 'co';
+import {
+  request,
+  cleanup,
+  createUser,
+  createProject,
+  getTemplatesByProjectId
+} from './../../../supertest';
+
+describe('given we want to modify templates', () => {
+  let currentUser;
+  let currentProject;
+
+  const newProject = {
+    name: 'new project',
+    description: 'new project description'
+  };
+  const newTemplate = {
+    name: 'new template',
+    description: 'new template description'
+  };
+
+  const getTemplatesRequest = (projectId) => request
+    .get(`/api/projects/${projectId}/templates`)
+    .set('Content-type', 'application/json')
+    .set('Authorization', `Bearer ${currentUser.sessionToken}`);
+
+  const getTemplateByIdRequest = (projectId, templateId) => request
+      .get(`/api/projects/${projectId}/templates/${templateId}`)
+      .set('Content-type', 'application/json')
+      .set('Authorization', `Bearer ${currentUser.sessionToken}`);
+
+  const addTemplateRequest = (projectId, template) => request
+    .post(`/api/projects/${projectId}/templates`)
+    .set('Content-type', 'application/json')
+    .set('Authorization', `Bearer ${currentUser.sessionToken}`)
+    .send(newTemplate);
+
+  const updateTemplateDevVersionRequest = (projectId, templateId, data) => {
+    const url = `/api/projects/${projectId}/templates/${templateId}/versions/development`;
+    return request
+      .post(url)
+      .set('Content-type', 'application/json')
+      .set('Authorization', `Bearer ${currentUser.sessionToken}`)
+      .send(data);
+  }
+
+  const promoteTemplateProdVersionRequest = (projectId, templateId, data) => {
+    const url = `/api/projects/${projectId}/templates/${templateId}/versions/production`;
+    return request
+      .post(url)
+      .set('Content-type', 'application/json')
+      .set('Authorization', `Bearer ${currentUser.sessionToken}`)
+      .send(data);
+  }
+
+  beforeEach((done) => {
+    co(function*() {
+      yield cleanup();
+      currentUser = yield createUser();
+      currentProject = yield createProject(currentUser, newProject);
+    }).then(() => { done(); })
+      .catch((err) => { done(err); });
+  });
+
+  it('should not have any template',
+    (done) => getTemplatesRequest(currentProject.objectId).expect(200).end(done));
+
+  describe('WHEN adding a new template', () => {
+    it('should make the request with success',
+      (done) => addTemplateRequest(currentProject.objectId, newTemplate)
+        .expect(200).end(done));
+
+    describe('WHEN adding template is finished', () => {
+      let firstAddedTemplate = null;
+      beforeEach((done) => {
+        addTemplateRequest(currentProject.objectId, newTemplate)
+          .end((err, res) => {
+            if (err) return done(err);
+            firstAddedTemplate = res.body;
+            done();
+          });
+      });
+
+      it('templated should have the same name',
+        () => expect(firstAddedTemplate.name).to.equal(newTemplate.name));
+
+      describe('WHEN getting the template by id', () => {
+        it('should make the request with success',
+          (done) => getTemplateByIdRequest(currentProject.objectId, firstAddedTemplate.objectId)
+            .expect(200).end(done));
+
+        describe('WHEN get template by id request is finished', () => {
+          let retreivedTemplate = null;
+          beforeEach((done) => getTemplateByIdRequest(currentProject.objectId, firstAddedTemplate.objectId).end((err, res) => {
+            if (err) return done(err);
+            retreivedTemplate = res.body;
+            done();
+          }));
+
+          it('should have an object id',
+            () => expect(retreivedTemplate.objectId).not.to.be.undefined);
+
+          it('should have the correct name',
+            () => expect(retreivedTemplate.name).to.equal(newTemplate.name));
+
+          it('should have the correct description',
+            () => expect(retreivedTemplate.description).to.equal(newTemplate.description));
+
+          it('should have the one development version property`',
+            () => expect(retreivedTemplate.developmentVersion).not.to.be.undefined);
+
+          it('should have the default html development version `<div><%=title%><div>`',
+            () => expect(retreivedTemplate.developmentVersion.html).to.equal('<div><%=title%><div>'));
+
+          it('should have the sample json development version `{title: \'Welcome!\'}`',
+            () => expect(retreivedTemplate.developmentVersion.sampleJson).to.equal('{title: \'Welcome\'}'));
+
+          it('should have the one template version in versions array`',
+            () => expect(retreivedTemplate.versions.length).to.equal(1));
+
+          it('should have the default html in the first version `<div><%=title%><div>`',
+            () => expect(retreivedTemplate.versions[0].html).to.equal('<div><%=title%><div>'));
+
+          it('should have the sample json in the first version `{title: \'Welcome!\'}`',
+            () => expect(retreivedTemplate.versions[0].sampleJson).to.equal('{title: \'Welcome\'}'));
+        });
+      });
+
+      describe('WHEN updating development template', () => {
+        const devVersion = {
+          html: 'new html',
+          sampleJson: 'new sample json'
+        };
+
+        it('Should return 200',
+          (done) => updateTemplateDevVersionRequest(currentProject.objectId, firstAddedTemplate.objectId, devVersion)
+            .expect(200).end(done));
+
+        describe('WHEN getting the template by id', () => {
+          let retreivedTemplate = null;
+          beforeEach((done) => updateTemplateDevVersionRequest(currentProject.objectId, firstAddedTemplate.objectId, devVersion)
+            .end(done));
+
+          beforeEach((done) => getTemplateByIdRequest(currentProject.objectId, firstAddedTemplate.objectId).end((err, res) => {
+            if (err) return done(err);
+            retreivedTemplate = res.body;
+            done();
+          }));
+
+          it('should have the updated dev version html',
+            () => expect(retreivedTemplate.developmentVersion.html).to.equal(devVersion.html));
+
+          it('should have the updated dev version sample json',
+            () => expect(retreivedTemplate.developmentVersion.sampleJson).to.equal(devVersion.sampleJson));
+        });
+      });
+
+      describe('WHEN updating production template', () => {
+        const prodVersion = {
+          html: 'new version of html',
+          sampleJson: 'new version json'
+        };
+
+        it('Should return 200',
+          (done) => promoteTemplateProdVersionRequest(currentProject.objectId, firstAddedTemplate.objectId, prodVersion)
+            .expect(200).end(done));
+
+        describe('WHEN getting the template by id', () => {
+          let retreivedTemplate = null;
+          beforeEach((done) => promoteTemplateProdVersionRequest(currentProject.objectId, firstAddedTemplate.objectId, prodVersion)
+            .end(done));
+
+          beforeEach((done) => getTemplateByIdRequest(currentProject.objectId, firstAddedTemplate.objectId).end((err, res) => {
+            if (err) return done(err);
+            retreivedTemplate = res.body;
+            done();
+          }));
+
+          it('should have 2 versions',
+            () => expect(retreivedTemplate.versions.length).to.equal(2));
+
+          it('should have initial html in first version',
+            () => expect(retreivedTemplate.versions[0].html).to.equal('<div><%=title%><div>'));
+
+          it('should have `new version of html` in second version html',
+            () => expect(retreivedTemplate.versions[1].html).to.equal('new version of html'));
+
+          it('should have `new version json` in second version sample json',
+            () => expect(retreivedTemplate.versions[1].sampleJson).to.equal('new version json'));
+        });
+      });
+    });
+  });
+});

--- a/src/api/modules/templates/__tests__/templates-crud-test.js
+++ b/src/api/modules/templates/__tests__/templates-crud-test.js
@@ -7,7 +7,7 @@ import {
   getTemplatesByProjectId
 } from './../../../supertest';
 
-describe('given we want to modify templates', () => {
+describe('given we want to CRUD templates', () => {
   let currentUser;
   let currentProject;
 
@@ -88,13 +88,11 @@ describe('given we want to modify templates', () => {
 
         describe('WHEN get template by id request is finished', () => {
           let retreivedTemplate = null;
-          beforeEach((done) => {
-            getTemplateByIdRequest(currentProject.objectId, firstAddedTemplate.objectId).end((err, res) => {
-              if (err) return done(err);
-              retreivedTemplate = res.body;
-              done();
-            });
-          });
+          beforeEach((done) => getTemplateByIdRequest(currentProject.objectId, firstAddedTemplate.objectId).end((err, res) => {
+            if (err) return done(err);
+            retreivedTemplate = res.body;
+            done();
+          }));
 
           it('should have an object id',
             () => expect(retreivedTemplate.objectId).not.to.be.undefined);

--- a/src/api/modules/templates/index.js
+++ b/src/api/modules/templates/index.js
@@ -7,8 +7,10 @@ import {
   updateTemplate,
   deleteTemplate
 } from './templates';
+import { insertTemplateVersion } from './templateVersions';
 
 export function setupRoutes(app, prefix = '/api/projects/:projectId/templates') {
+
   app.get(`${prefix}/`, requiredAuthenticated, (req, res) => {
     const user = req.user;
     const projectId = req.params.projectId;
@@ -34,6 +36,27 @@ export function setupRoutes(app, prefix = '/api/projects/:projectId/templates') 
     const template = req.body;
 
     insertTemplate(user.objectId, projectId, template)
+      .then((response) => res.json(response))
+      .catch((err) => sendHttpError(res, { code: 400, err }));
+  });
+
+  app.post(`${prefix}/:templateId/versions/development`, requiredAuthenticated, (req, res) => {
+    const user = req.user;
+    const projectId = req.params.projectId;
+    const templateId = req.params.templateId;
+    const developmentVersion = req.body;
+    const template = { developmentVersion };
+
+    updateTemplate(user.objectId, projectId, templateId, template)
+      .then((response) => res.json(response))
+      .catch((err) => sendHttpError(res, { code: 400, err }));
+  });
+
+  app.post(`${prefix}/:templateId/versions/production`, requiredAuthenticated, (req, res) => {
+    const templateId = req.params.templateId;
+    const version = req.body;
+
+    insertTemplateVersion(templateId, version)
       .then((response) => res.json(response))
       .catch((err) => sendHttpError(res, { code: 400, err }));
   });

--- a/src/api/modules/templates/templateVersions.js
+++ b/src/api/modules/templates/templateVersions.js
@@ -1,0 +1,44 @@
+import co from 'co';
+import {TemplateVersion, toJson} from './../../mongoose';
+
+export function getDefaultVersion() {
+  return {
+    html: `<div><%=title%><div>`,
+    sampleJson: `{title: 'Welcome'}`
+  };
+}
+
+export function getTemplateVersionById(id) {
+  return co(function*() {
+    const templateVersion = yield TemplateVersion.findOne({
+      _id: id
+    });
+    return toJson(templateVersion);
+  });
+}
+
+export function getTemplateVersionsByTemplateId(templateId) {
+  return co(function*() {
+    const templateVersion = yield TemplateVersion.find({
+      templateId
+    });
+    return toJson(templateVersion) || [];
+  });
+}
+
+export function insertTemplateVersion(templateId, template) {
+  return co(function*() {
+    if (!templateId) {
+      throw new Error('required parameter templateId is missing');
+    }
+
+    const defaultVersion = getDefaultVersion();
+    defaultVersion.templateId = templateId;
+    defaultVersion.isProduction = false;
+    defaultVersion.createdAt = new Date();
+
+    const newVersion = new TemplateVersion(Object.assign({}, defaultVersion, template));
+    const templateVersion = yield newVersion.save();
+    return toJson(templateVersion);
+  });
+}

--- a/src/api/mongoose.js
+++ b/src/api/mongoose.js
@@ -30,11 +30,20 @@ const layoutSchema = new Schema({
   value: { type: String }
 });
 
+const templateVersionSchemaBase = {
+  html: { type: String },
+  sampleJson: { type: String },
+  translations: [],
+};
+const templateVersionSchema = new Schema(Object.assign({}, templateVersionSchemaBase, {
+  templateId: { type: String, required: true, index: true },
+  isProduction: { type: Boolean, required: true, index: true },
+  createdAt: { type: Date }
+}));
 const templateSchema = new Schema({
   name: { type: String },
   description: { type: String },
-  templateHtml: { type: String },
-  sampleJson: { type: String }
+  developmentVersion: templateVersionSchemaBase
 });
 
 const projectSchema = new Schema({
@@ -51,6 +60,7 @@ layoutSchema.set('toJSON', schemaSettings);
 projectSchema.set('toJSON', schemaSettings);
 userSchema.set('toJSON', schemaSettings);
 templateSchema.set('toJSON', schemaSettings);
+templateVersionSchema.set('toJSON', schemaSettings);
 
 function mapEntity(entity) {
   if (!entity) {
@@ -71,12 +81,15 @@ export function toJson(entityOrArray) {
     return entityOrArray;
   }
   const isArray = typeof entityOrArray.map === 'function';
+
   if (isArray) {
     return mapEntitiesArray(entityOrArray);
   }
+
   return mapEntity(entityOrArray);
 }
 
 export const User = model('User', userSchema);
 export const Project = model('Project', projectSchema);
 export const Template = model('Template', templateSchema);
+export const TemplateVersion = model('TemplateVersion', templateVersionSchema);


### PR DESCRIPTION
Add support for template versioning at API level:
- added a new property `developmentVersion` for the current editor view. 
- added a Rest endpoint that will update the `developmentVersion` property:
`POST /api/projects/:projectId/templates/:templateId/versions/development`
- added a new collection and template object response array, named `versions` for all template versions
- added a Rest endpoint that will insert a new item in the `versions` array:
`POST /api/projects/:projectId/templates/:templateId/versions/production`